### PR TITLE
Update en-US.json

### DIFF
--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -6,5 +6,6 @@
     "newButton0122": "another button after clearing files in smartling",
     "newButton0122-2": "additional button, this one will be unauthorized",
     "newButton0122-3": "third button, comma added, prev is still unauth",
-    "newButton0122-4": "fourth button, prev job 18 will stay unauth, this one will auth"
+    "newButton0122-4": "fourth button, prev job 18 will stay unauth, this one will auth",
+    "newButton0122-5": "fifth button, prev job completed, only 1 string was translated the rest just moved over as english."
 }


### PR DESCRIPTION
so we now know that strings don't get moved over to the new job.